### PR TITLE
Add drag & drop support for file uploads

### DIFF
--- a/app/js/actions.js
+++ b/app/js/actions.js
@@ -257,14 +257,16 @@ export const setLoginError = () => {
 
 export const uploadFile = (file, xhr) => {
   return (dispatch, getState) => {
-    const { currentBucket, currentPath, web } = getState()
+    const { currentBucket, currentPath } = getState()
     const objectName = `${currentPath}${file.name}`
     const uploadUrl = `${window.location.origin}/minio/upload/${currentBucket}/${objectName}`
+
     xhr.open('PUT', uploadUrl, true)
     xhr.withCredentials = false
     xhr.setRequestHeader("Authorization", 'Bearer ' + localStorage.token)
     xhr.setRequestHeader('x-amz-date', Moment().utc().format('YYYYMMDDTHHmmss') + 'Z')
     dispatch(setUpload({inProgress: true, loaded: 0, total: file.size, filename: file.name}))
+
     xhr.upload.addEventListener('error', event => {
       dispatch(showAlert({
         type: 'danger',

--- a/app/js/components/Browse.js
+++ b/app/js/components/Browse.js
@@ -31,6 +31,7 @@ import Scrollbars from 'react-custom-scrollbars/lib/Scrollbars'
 import Dropdown from 'react-bootstrap/lib/Dropdown'
 import MenuItem from 'react-bootstrap/lib/MenuItem'
 import InputGroup from '../components/InputGroup'
+import Dropzone from '../components/Dropzone'
 
 import logo from '../../img/logo.svg'
 
@@ -556,6 +557,7 @@ export default class Browse extends React.Component {
                             showPolicy={this.showBucketPolicy.bind(this)}/>
 
                 <div className="fe-body">
+                    <Dropzone>
                     {alertBox}
 
                     <header className="mobile-header hidden-lg hidden-md">
@@ -841,6 +843,7 @@ export default class Browse extends React.Component {
                             </a>
                         </div>
                     </Modal>
+                    </Dropzone>
                 </div>
             </div>
         )

--- a/app/js/components/Dropzone.js
+++ b/app/js/components/Dropzone.js
@@ -1,0 +1,61 @@
+/*
+ * Minio Browser (C) 2016 Minio, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import React from 'react'
+import ReactDropzone from 'react-dropzone'
+import * as actions from '../actions'
+
+// Dropzone is a drag-and-drop element for uploading files. It will create a
+// landing zone of sorts that automatically receives the files.
+export default class Dropzone extends React.Component {
+
+    onDrop(files) {
+        files.forEach(file => {
+            let req = new XMLHttpRequest()
+
+            // Dispatch the upload.
+            web.dispatch(actions.uploadFile(file, req))
+        })
+    }
+
+    render() {
+        // Overwrite the default styling from react-dropzone; otherwise it
+        // won't handle child elements correctly.
+        const style = {
+            height: '100%',
+            borderWidth: '2px',
+            borderStyle: 'dashed',
+            borderColor: '#fff'
+        }
+        const activeStyle = {
+            backgroundColor: '#eee',
+            borderColor: '#777'
+        }
+        const rejectStyle = {
+            backgroundColor: '#ffdddd'
+        }
+
+        // disableClick means that it won't trigger a file upload box when
+        // the user clicks on a file.
+        return (
+            <ReactDropzone style={style} activeStyle={activeStyle}
+                rejectStyle={rejectStyle}
+                disableClick={true} onDrop={this.onDrop}>
+                {this.props.children}
+            </ReactDropzone>
+            )
+    }
+}

--- a/package.json
+++ b/package.json
@@ -62,6 +62,7 @@
     "humanize": "0.0.9",
     "react-custom-scrollbars": "^2.2.2",
     "react-dom": "^0.14.6",
+    "react-dropzone": "^3.5.3",
     "react-onclickout": "^2.0.4"
   }
 }


### PR DESCRIPTION
This adds rudimentary drag and drop support for uploading files to
buckets. It adds 'react-dropzone' as a dependency to do so and uses the
pre-existing functionality of `uploadFile` in actions.js.

Fixes https://github.com/minio/minio/issues/2049

There are two problems with this commit as-is:
1) the dropzone box does not use the space beneath the file list as well
[to be fixed]
2) dropzone component uses web.dispatch, a global (ew) instead of
injecting it to its props

And a screenshot:
![screen shot 2016-08-03 at 11 26 58 am](https://cloud.githubusercontent.com/assets/3038254/17377114/4ae10cd2-596d-11e6-91d3-4509cc836380.png)

/cc @harshavardhana 