### PR TITLE
allow for multiple file upload abort/status modal

### DIFF
--- a/app/js/reducers.js
+++ b/app/js/reducers.js
@@ -18,7 +18,7 @@ import * as actions from './actions'
 import { minioBrowserPrefix } from './constants'
 
 export default (state = {buckets:[], visibleBuckets:[], objects:[], storageInfo:{}, serverInfo: {},
-                currentBucket: '', currentPath: '', showMakeBucketModal: false, upload: {},
+                currentBucket: '', currentPath: '', showMakeBucketModal: false, uploads: {},
                 alert: {show: false, type: 'danger', message: ''}, loginError : false,
                 sortNameOrder: false, sortSizeOrder: false, sortDateOrder: false,
                 latestUiVersion: currentUiVersion, sideBarActive: false,
@@ -61,8 +61,19 @@ export default (state = {buckets:[], visibleBuckets:[], objects:[], storageInfo:
       if (idx > -1) newState.objects.splice(idx, 1)
       newState.objects = [action.object, ...newState.objects]
       break
-    case actions.SET_UPLOAD:
-      newState.upload = action.upload
+    case actions.UPLOAD_PROGRESS:
+      newState.uploads[action.slug].loaded = action.loaded
+      break
+    case actions.ADD_UPLOAD:
+      newState.uploads[action.slug] = {
+        loaded: 0,
+        size: action.size,
+        xhr: action.xhr,
+        name: action.name
+      }
+      break
+    case actions.STOP_UPLOAD:
+      delete newState.uploads[action.slug]
       break
     case actions.SET_ALERT:
       if (newState.alert.alertTimeout) clearTimeout(newState.alert.alertTimeout)


### PR DESCRIPTION
This commit allows the miniobrowser to better handle multiple file
uploads in multiple ways. First, it updates the state so as to keep
track of each individual upload (by unique slugs) and its status.
Second, it combines the statuses of all uploads into one single status
modal for display when uploading (see screenshot attached). Finally, the
abort modal now aborts all downloads instead of just the one.

Fixes: https://github.com/minio/miniobrowser/issues/171

the new modal in action:
![screen shot 2016-08-05 at 12 28 10 am](https://cloud.githubusercontent.com/assets/3038254/17429728/1dd2de3a-5aa5-11e6-814d-7603a3ca0512.png)