### PR TITLE
fix state updates and imports

### DIFF
--- a/app/js/components/ConfirmModal.js
+++ b/app/js/components/ConfirmModal.js
@@ -14,6 +14,7 @@
  * limitations under the License.
  */
 
+import React from 'react'
 import Modal from 'react-bootstrap/lib/Modal'
 import ModalBody from 'react-bootstrap/lib/ModalBody'
 

--- a/app/js/reducers.js
+++ b/app/js/reducers.js
@@ -63,17 +63,21 @@ export default (state = {buckets:[], visibleBuckets:[], objects:[], storageInfo:
       newState.objects = [action.object, ...newState.objects]
       break
     case actions.UPLOAD_PROGRESS:
+      newState.uploads = Object.assign({}, newState.uploads)
       newState.uploads[action.slug].loaded = action.loaded
       break
     case actions.ADD_UPLOAD:
-      newState.uploads[action.slug] = {
-        loaded: 0,
-        size: action.size,
-        xhr: action.xhr,
-        name: action.name
-      }
+      newState.uploads = Object.assign({}, newState.uploads, {
+        [action.slug]: {
+          loaded: 0,
+          size: action.size,
+          xhr: action.xhr,
+          name: action.name
+        }
+      })
       break
     case actions.STOP_UPLOAD:
+      newState.uploads = Object.assign({}, newState.uploads)
       delete newState.uploads[action.slug]
       break
     case actions.SET_ALERT:


### PR DESCRIPTION
This fixes a bug that I introduced (ah ha ha... :L) where the state
would not update because redux only shallowly compares objects in the
state to check whether or not to update components that subscribe to
those changes. Because I only modified the object beneath rather than
modifying the object at the top level, it wouldn't usually trigger
updates, although it would trigger updates every so often (for reasons I
don't know).

:) @krishnasrinivas @harshavardhana please review when you have the time.

Now, at least, the modals are beautiful.